### PR TITLE
Removing log4j:log4j dependency

### DIFF
--- a/ncds-sdk/pom.xml
+++ b/ncds-sdk/pom.xml
@@ -110,9 +110,9 @@
         </dependency>
 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.12.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -120,7 +120,7 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>1.3.176</version>
-
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/ncds-sdk/src/test/resources/log4j.xml
+++ b/ncds-sdk/src/test/resources/log4j.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
-<log4j:configuration debug="true" xmlns:log4j='http://jakarta.apache.org/log4j/'>
+<log4j:configuration debug="false" xmlns:log4j='http://jakarta.apache.org/log4j/'>
 
 
 <!--    <appender name="console" class="org.apache.log4j.ConsoleAppender">-->

--- a/ncdssdk-client/src/main/resources/log4j.xml
+++ b/ncdssdk-client/src/main/resources/log4j.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
-<log4j:configuration debug="true" xmlns:log4j='http://jakarta.apache.org/log4j/'>
+<log4j:configuration debug="false" xmlns:log4j='http://jakarta.apache.org/log4j/'>
 
     <appender name="FILE" class="org.apache.log4j.FileAppender">
 


### PR DESCRIPTION
Becuase log4j depedancy has vulnerablitiy, we are removing it.